### PR TITLE
Create basic command set for loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,6 @@
 
 # Folder
 .vscode/
-commands/
+
+# Ignore compiled command modules but keep source files
+commands/**/*.dll

--- a/commands/cat/cat.cpp
+++ b/commands/cat/cat.cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <windows.h>
+
+// Command: cat
+// Display the contents of one or more files
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args) {
+    if (args.size() < 2) {
+        std::cout << "Usage: cat <file1> [file2] [file3] ...\n";
+        std::cout << "Display the contents of one or more files.\n";
+        return;
+    }
+
+    for (size_t i = 1; i < args.size(); ++i) {
+        std::string filename = args[i];
+        std::ifstream file(filename);
+
+        if (!file.is_open()) {
+            std::cerr << "cat: " << filename << ": No such file or directory\n";
+            continue;
+        }
+
+        std::string line;
+        while (std::getline(file, line)) {
+            std::cout << line << "\n";
+        }
+
+        file.close();
+    }
+}

--- a/commands/cat/cat.h
+++ b/commands/cat/cat.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <vector>
+#include <string>
+
+// Command: cat
+// Function declaration for DLL export
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args);

--- a/commands/clear/clear.cpp
+++ b/commands/clear/clear.cpp
@@ -1,0 +1,46 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <windows.h>
+
+// Command: clear
+// Clear the terminal screen
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args) {
+    HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
+    CONSOLE_SCREEN_BUFFER_INFO csbi;
+    DWORD count;
+    DWORD cellCount;
+    COORD homeCoords = { 0, 0 };
+
+    // Get the number of cells in the current buffer
+    if (!GetConsoleScreenBufferInfo(hConsole, &csbi)) {
+        return;
+    }
+    cellCount = csbi.dwSize.X * csbi.dwSize.Y;
+
+    // Fill the entire buffer with spaces
+    if (!FillConsoleOutputCharacter(
+        hConsole,
+        (TCHAR)' ',
+        cellCount,
+        homeCoords,
+        &count
+    )) {
+        return;
+    }
+
+    // Fill the entire buffer with the current colors and attributes
+    if (!FillConsoleOutputAttribute(
+        hConsole,
+        csbi.wAttributes,
+        cellCount,
+        homeCoords,
+        &count
+    )) {
+        return;
+    }
+
+    // Move the cursor home
+    SetConsoleCursorPosition(hConsole, homeCoords);
+}

--- a/commands/clear/clear.h
+++ b/commands/clear/clear.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <vector>
+#include <string>
+
+// Command: clear
+// Function declaration for DLL export
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args);

--- a/commands/cp/cp.cpp
+++ b/commands/cp/cp.cpp
@@ -1,0 +1,48 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <windows.h>
+
+// Command: cp
+// Copy files
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args) {
+    if (args.size() < 3) {
+        std::cout << "Usage: cp <source> <destination>\n";
+        std::cout << "Copy a file from source to destination.\n";
+        return;
+    }
+
+    std::string source = args[1];
+    std::string destination = args[2];
+
+    // Check if source file exists
+    DWORD fileAttrs = GetFileAttributesA(source.c_str());
+
+    if (fileAttrs == INVALID_FILE_ATTRIBUTES) {
+        std::cerr << "cp: cannot stat '" << source << "': No such file\n";
+        return;
+    }
+
+    if (fileAttrs & FILE_ATTRIBUTE_DIRECTORY) {
+        std::cerr << "cp: '" << source << "' is a directory (directory copying not supported)\n";
+        return;
+    }
+
+    // Check if destination is a directory
+    DWORD destAttrs = GetFileAttributesA(destination.c_str());
+    if (destAttrs != INVALID_FILE_ATTRIBUTES && (destAttrs & FILE_ATTRIBUTE_DIRECTORY)) {
+        // Extract filename from source and append to destination directory
+        size_t pos = source.find_last_of("\\/");
+        std::string filename = (pos == std::string::npos) ? source : source.substr(pos + 1);
+        destination = destination + "\\" + filename;
+    }
+
+    // Copy the file
+    if (CopyFileA(source.c_str(), destination.c_str(), FALSE)) {
+        std::cout << "File copied from '" << source << "' to '" << destination << "' successfully.\n";
+    } else {
+        DWORD error = GetLastError();
+        std::cerr << "cp: cannot copy '" << source << "' to '" << destination << "': Error " << error << "\n";
+    }
+}

--- a/commands/cp/cp.h
+++ b/commands/cp/cp.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <vector>
+#include <string>
+
+// Command: cp
+// Function declaration for DLL export
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args);

--- a/commands/date/date.cpp
+++ b/commands/date/date.cpp
@@ -1,0 +1,34 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <windows.h>
+#include <ctime>
+
+// Command: date
+// Display the current date and time
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args) {
+    SYSTEMTIME st;
+    GetLocalTime(&st);
+
+    // Day of week names
+    const char* dayNames[] = {
+        "Sunday", "Monday", "Tuesday", "Wednesday",
+        "Thursday", "Friday", "Saturday"
+    };
+
+    // Month names
+    const char* monthNames[] = {
+        "January", "February", "March", "April", "May", "June",
+        "July", "August", "September", "October", "November", "December"
+    };
+
+    std::cout << dayNames[st.wDayOfWeek] << ", "
+              << monthNames[st.wMonth - 1] << " "
+              << st.wDay << ", "
+              << st.wYear << " "
+              << (st.wHour < 10 ? "0" : "") << st.wHour << ":"
+              << (st.wMinute < 10 ? "0" : "") << st.wMinute << ":"
+              << (st.wSecond < 10 ? "0" : "") << st.wSecond
+              << "\n";
+}

--- a/commands/date/date.h
+++ b/commands/date/date.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <vector>
+#include <string>
+
+// Command: date
+// Function declaration for DLL export
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args);

--- a/commands/echo/echo.cpp
+++ b/commands/echo/echo.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <windows.h>
+
+// Command: echo
+// Display a line of text
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args) {
+    if (args.size() < 2) {
+        std::cout << "\n";
+        return;
+    }
+
+    for (size_t i = 1; i < args.size(); ++i) {
+        std::cout << args[i];
+        if (i < args.size() - 1) {
+            std::cout << " ";
+        }
+    }
+    std::cout << "\n";
+}

--- a/commands/echo/echo.h
+++ b/commands/echo/echo.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <vector>
+#include <string>
+
+// Command: echo
+// Function declaration for DLL export
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args);

--- a/commands/hostname/hostname.cpp
+++ b/commands/hostname/hostname.cpp
@@ -1,0 +1,18 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <windows.h>
+
+// Command: hostname
+// Display the computer name
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args) {
+    char computerName[MAX_COMPUTERNAME_LENGTH + 1];
+    DWORD computerNameLen = sizeof(computerName);
+
+    if (GetComputerNameA(computerName, &computerNameLen)) {
+        std::cout << computerName << "\n";
+    } else {
+        std::cerr << "hostname: Unable to retrieve computer name\n";
+    }
+}

--- a/commands/hostname/hostname.h
+++ b/commands/hostname/hostname.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <vector>
+#include <string>
+
+// Command: hostname
+// Function declaration for DLL export
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args);

--- a/commands/mkdir/mkdir.cpp
+++ b/commands/mkdir/mkdir.cpp
@@ -1,0 +1,30 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <windows.h>
+
+// Command: mkdir
+// Create directories
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args) {
+    if (args.size() < 2) {
+        std::cout << "Usage: mkdir <directory1> [directory2] ...\n";
+        std::cout << "Create one or more directories.\n";
+        return;
+    }
+
+    for (size_t i = 1; i < args.size(); ++i) {
+        std::string dirName = args[i];
+
+        if (CreateDirectoryA(dirName.c_str(), NULL)) {
+            std::cout << "Directory '" << dirName << "' created successfully.\n";
+        } else {
+            DWORD error = GetLastError();
+            if (error == ERROR_ALREADY_EXISTS) {
+                std::cerr << "mkdir: cannot create directory '" << dirName << "': Directory already exists\n";
+            } else {
+                std::cerr << "mkdir: cannot create directory '" << dirName << "': Error " << error << "\n";
+            }
+        }
+    }
+}

--- a/commands/mkdir/mkdir.h
+++ b/commands/mkdir/mkdir.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <vector>
+#include <string>
+
+// Command: mkdir
+// Function declaration for DLL export
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args);

--- a/commands/mv/mv.cpp
+++ b/commands/mv/mv.cpp
@@ -1,0 +1,47 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <windows.h>
+
+// Command: mv
+// Move or rename files
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args) {
+    if (args.size() < 3) {
+        std::cout << "Usage: mv <source> <destination>\n";
+        std::cout << "Move or rename a file from source to destination.\n";
+        return;
+    }
+
+    std::string source = args[1];
+    std::string destination = args[2];
+
+    // Check if source exists
+    DWORD fileAttrs = GetFileAttributesA(source.c_str());
+
+    if (fileAttrs == INVALID_FILE_ATTRIBUTES) {
+        std::cerr << "mv: cannot stat '" << source << "': No such file or directory\n";
+        return;
+    }
+
+    // Check if destination is a directory
+    DWORD destAttrs = GetFileAttributesA(destination.c_str());
+    if (destAttrs != INVALID_FILE_ATTRIBUTES && (destAttrs & FILE_ATTRIBUTE_DIRECTORY)) {
+        // Extract filename from source and append to destination directory
+        size_t pos = source.find_last_of("\\/");
+        std::string filename = (pos == std::string::npos) ? source : source.substr(pos + 1);
+        destination = destination + "\\" + filename;
+    }
+
+    // Move the file
+    if (MoveFileA(source.c_str(), destination.c_str())) {
+        std::cout << "Moved '" << source << "' to '" << destination << "' successfully.\n";
+    } else {
+        DWORD error = GetLastError();
+        if (error == ERROR_ALREADY_EXISTS) {
+            std::cerr << "mv: cannot move '" << source << "' to '" << destination << "': File already exists\n";
+        } else {
+            std::cerr << "mv: cannot move '" << source << "' to '" << destination << "': Error " << error << "\n";
+        }
+    }
+}

--- a/commands/mv/mv.h
+++ b/commands/mv/mv.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <vector>
+#include <string>
+
+// Command: mv
+// Function declaration for DLL export
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args);

--- a/commands/rm/rm.cpp
+++ b/commands/rm/rm.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <windows.h>
+
+// Command: rm
+// Remove files
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args) {
+    if (args.size() < 2) {
+        std::cout << "Usage: rm <file1> [file2] ...\n";
+        std::cout << "Remove one or more files.\n";
+        std::cout << "Warning: This operation is irreversible!\n";
+        return;
+    }
+
+    for (size_t i = 1; i < args.size(); ++i) {
+        std::string filename = args[i];
+
+        // Check if it's a file (not a directory)
+        DWORD fileAttrs = GetFileAttributesA(filename.c_str());
+
+        if (fileAttrs == INVALID_FILE_ATTRIBUTES) {
+            std::cerr << "rm: cannot remove '" << filename << "': No such file\n";
+            continue;
+        }
+
+        if (fileAttrs & FILE_ATTRIBUTE_DIRECTORY) {
+            std::cerr << "rm: cannot remove '" << filename << "': Is a directory (use rmdir instead)\n";
+            continue;
+        }
+
+        if (DeleteFileA(filename.c_str())) {
+            std::cout << "File '" << filename << "' removed successfully.\n";
+        } else {
+            DWORD error = GetLastError();
+            std::cerr << "rm: cannot remove '" << filename << "': Error " << error << "\n";
+        }
+    }
+}

--- a/commands/rm/rm.h
+++ b/commands/rm/rm.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <vector>
+#include <string>
+
+// Command: rm
+// Function declaration for DLL export
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args);

--- a/commands/rmdir/rmdir.cpp
+++ b/commands/rmdir/rmdir.cpp
@@ -1,0 +1,32 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <windows.h>
+
+// Command: rmdir
+// Remove empty directories
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args) {
+    if (args.size() < 2) {
+        std::cout << "Usage: rmdir <directory1> [directory2] ...\n";
+        std::cout << "Remove one or more empty directories.\n";
+        return;
+    }
+
+    for (size_t i = 1; i < args.size(); ++i) {
+        std::string dirName = args[i];
+
+        if (RemoveDirectoryA(dirName.c_str())) {
+            std::cout << "Directory '" << dirName << "' removed successfully.\n";
+        } else {
+            DWORD error = GetLastError();
+            if (error == ERROR_DIR_NOT_EMPTY) {
+                std::cerr << "rmdir: cannot remove '" << dirName << "': Directory not empty\n";
+            } else if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND) {
+                std::cerr << "rmdir: cannot remove '" << dirName << "': No such directory\n";
+            } else {
+                std::cerr << "rmdir: cannot remove '" << dirName << "': Error " << error << "\n";
+            }
+        }
+    }
+}

--- a/commands/rmdir/rmdir.h
+++ b/commands/rmdir/rmdir.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <vector>
+#include <string>
+
+// Command: rmdir
+// Function declaration for DLL export
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args);

--- a/commands/touch/touch.cpp
+++ b/commands/touch/touch.cpp
@@ -1,0 +1,57 @@
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <windows.h>
+
+// Command: touch
+// Create empty files or update file timestamps
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args) {
+    if (args.size() < 2) {
+        std::cout << "Usage: touch <file1> [file2] ...\n";
+        std::cout << "Create empty files or update file timestamps.\n";
+        return;
+    }
+
+    for (size_t i = 1; i < args.size(); ++i) {
+        std::string filename = args[i];
+
+        // Check if file exists
+        DWORD fileAttrs = GetFileAttributesA(filename.c_str());
+
+        if (fileAttrs == INVALID_FILE_ATTRIBUTES) {
+            // File doesn't exist, create it
+            std::ofstream file(filename);
+            if (file.is_open()) {
+                file.close();
+                std::cout << "File '" << filename << "' created.\n";
+            } else {
+                std::cerr << "touch: cannot create file '" << filename << "'\n";
+            }
+        } else {
+            // File exists, update timestamp
+            HANDLE hFile = CreateFileA(
+                filename.c_str(),
+                FILE_WRITE_ATTRIBUTES,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                NULL,
+                OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL,
+                NULL
+            );
+
+            if (hFile != INVALID_HANDLE_VALUE) {
+                SYSTEMTIME st;
+                FILETIME ft;
+                GetSystemTime(&st);
+                SystemTimeToFileTime(&st, &ft);
+                SetFileTime(hFile, NULL, &ft, &ft);
+                CloseHandle(hFile);
+                std::cout << "File '" << filename << "' timestamp updated.\n";
+            } else {
+                std::cerr << "touch: cannot update timestamp for '" << filename << "'\n";
+            }
+        }
+    }
+}

--- a/commands/touch/touch.h
+++ b/commands/touch/touch.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <vector>
+#include <string>
+
+// Command: touch
+// Function declaration for DLL export
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args);

--- a/commands/whoami/whoami.cpp
+++ b/commands/whoami/whoami.cpp
@@ -1,0 +1,18 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <windows.h>
+
+// Command: whoami
+// Display the current username
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args) {
+    char username[256];
+    DWORD usernameLen = sizeof(username);
+
+    if (GetUserNameA(username, &usernameLen)) {
+        std::cout << username << "\n";
+    } else {
+        std::cerr << "whoami: Unable to retrieve username\n";
+    }
+}

--- a/commands/whoami/whoami.h
+++ b/commands/whoami/whoami.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <vector>
+#include <string>
+
+// Command: whoami
+// Function declaration for DLL export
+
+extern "C" __declspec(dllexport) void execute(const std::vector<std::string>& args);


### PR DESCRIPTION
Created a comprehensive set of basic shell commands that will be automatically loaded when present in the commands directory:

File operations:
- cat: Display file contents
- touch: Create empty files or update timestamps
- rm: Remove files
- cp: Copy files
- mv: Move or rename files

Directory operations:
- mkdir: Create directories
- rmdir: Remove empty directories

Output and display:
- echo: Print text to console
- clear: Clear terminal screen
- date: Display current date and time

System information:
- whoami: Display current username
- hostname: Display computer name

Each command is implemented as a DLL module with proper error handling and Windows API integration. Commands follow the standard Actinium module structure with .cpp and .h files.

Updated .gitignore to track command source files while excluding compiled .dll files.